### PR TITLE
Fix mutable sample points bug

### DIFF
--- a/extensible_splines/splines.py
+++ b/extensible_splines/splines.py
@@ -128,10 +128,17 @@ def get_sample_points(number_of_points:int):
     return [m/float(number_of_points) for m in range(1, number_of_points)]
 
 def correct_sample_ends(raw_points:List[float], is_final:bool=False):
-    raw_points.insert(0,0.0)
+    """Return a copy of ``raw_points`` with 0 prepended and 1 appended if final.
+
+    The previous implementation mutated ``raw_points`` in-place which caused
+    successive calls with the same list to accumulate extra leading zeros (and
+    trailing ones).  ``get_all_points_all_segments`` reused the same list for
+    every segment, so later segments contained duplicated samples.  By creating
+    a new list, each segment receives a clean set of samples."""
+    new_points = [0.0] + list(raw_points)
     if is_final:
-        raw_points.append(1.0)
-    return raw_points
+        new_points.append(1.0)
+    return new_points
 
 # Interpolant and Centroid classes
 

--- a/test/test_sample_point_generation.py
+++ b/test/test_sample_point_generation.py
@@ -1,0 +1,17 @@
+import unittest
+import extensible_splines.splines as es
+
+class TestSamplePointGeneration(unittest.TestCase):
+    def test_sample_points_not_mutated(self):
+        spline = es.HermiteSpline()
+        spline.set_control_points({i: i for i in range(5)})
+        interpolant = es.Interpolant(spline)
+        pts = interpolant.get_all_points_all_segments(5)
+        expected_len = 5 * len(spline.segments) + 1
+        self.assertEqual(len(pts), expected_len)
+        # verify the second segment does not start with duplicate point
+        first_seg_len = 5  # points_per_segment
+        self.assertNotEqual(pts[first_seg_len], pts[first_seg_len + 1])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- avoid mutating sample point lists when generating interpolated points
- add regression test for sample point handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683faf2466488322b047cbdfda7e0dc6